### PR TITLE
updated to CUBA 6.9; version 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 05.06.2018
+
+### Dependencies
+- CUBA 6.9.x
+
 ## [0.5.0] - 12.02.2018
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ CUBA component that allows to write generic features for a Controller and use th
 
 | Platform Version | Add-on Version |
 | ---------------- | -------------- |
+| 6.9.x            | 0.6.x          |
 | 6.8.x            | 0.5.x          |
 | 6.7.x            | 0.4.x          |
 | 6.6.x            | 0.2.x - 0.3.x  |

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-    ext.cubaVersion = '6.8.0'
+    ext.cubaVersion = '6.9.0'
     repositories {
         maven {
             url 'https://repo.cuba-platform.com/content/groups/work'
@@ -25,7 +25,7 @@ def coreModule = project(':declarativecontrollers-core')
 def guiModule = project(':declarativecontrollers-gui')
 def webModule = project(':declarativecontrollers-web')
 
-def servletApi = 'org.apache.tomcat:tomcat-servlet-api:8.0.26'
+def servletApi = 'javax.servlet:javax.servlet-api:3.1.0'
 
 
 apply(plugin: 'idea')
@@ -36,7 +36,7 @@ def bintrayRepositoryUrl = "https://api.bintray.com/maven/balvi/cuba-components/
 cuba {
     artifact {
         group = 'de.balvi.cuba.declarativecontrollers'
-        version = '0.5.0'
+        version = '0.6.0'
         isSnapshot = false
     }
     tomcat {

--- a/studio-settings.xml
+++ b/studio-settings.xml
@@ -3,5 +3,9 @@
     <functionalitySettings>
         <functionality id="oneToOneIndex"
                        state="ENABLE"/>
+        <functionality id="joinedInheritanceDeleteCascade"
+                       state="ENABLE"/>
+        <functionality id="newFkConstraintNaming"
+                       state="ENABLE"/>
     </functionalitySettings>
 </studio>


### PR DESCRIPTION
Hi,

this PR updates the component to CUBA 6.9 and sets the release to 0.6.0.

Documentation is updated accordingly.