### PR TITLE
0.7.0 - CUBA 6.10 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 24.10.2018
+
+### Dependencies
+- CUBA 6.9.x
+
 ## [0.6.0] - 05.06.2018
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ CUBA component that allows to write generic features for a Controller and use th
 
 | Platform Version | Add-on Version |
 | ---------------- | -------------- |
+| 6.10.x           | 0.7.x          |
 | 6.9.x            | 0.6.x          |
 | 6.8.x            | 0.5.x          |
 | 6.7.x            | 0.4.x          |

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-    ext.cubaVersion = '6.9.0'
+    ext.cubaVersion = '6.10.2'
     repositories {
         maven {
             url 'https://repo.cuba-platform.com/content/groups/work'
@@ -33,7 +33,7 @@ apply(plugin: 'cuba')
 cuba {
     artifact {
         group = 'de.balvi.cuba.declarativecontrollers'
-        version = '0.6.0'
+        version = "0.7.0"
         isSnapshot = false
     }
     tomcat {
@@ -145,7 +145,9 @@ configure([globalModule, coreModule, guiModule, webModule]) {
 
 }
 configure(globalModule) {
-    task enhance(type: CubaEnhancing)
+    entitiesEnhancing {
+        main { enabled = true }
+    }
 
     jar {
         manifest {

--- a/modules/core/db/init/hsql/10.create-db.sql
+++ b/modules/core/db/init/hsql/10.create-db.sql
@@ -1,16 +1,1 @@
--- begin DBCDC_CUSTOMER
-create table DBCDC_CUSTOMER (
-    ID varchar(36) not null,
-    VERSION integer not null,
-    CREATE_TS timestamp,
-    CREATED_BY varchar(50),
-    UPDATE_TS timestamp,
-    UPDATED_BY varchar(50),
-    DELETE_TS timestamp,
-    DELETED_BY varchar(50),
-    --
-    NAME varchar(255),
-    --
-    primary key (ID)
-)^
--- end DBCDC_CUSTOMER
+


### PR DESCRIPTION
Hi,

this PR switches to 0.7.0 release & adds CUBA 6.10 support.

I've tested it manually in data-import locally, everything seems to be ok!