### PR TITLE
CUBA 7 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ deploy/*
 modules/*/build/*
 out
 test-run
+.idea
+*.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   This release is more for fast upgrading your existing application if you rely on this app component. CUBA 7 Screens API
   will be supported in later releases.
 
+### Changed (Breaking!)
+- `ButtonsPanelHelper.getOrCreateButton` does not use `Component.Container`, but `com.haulmont.cuba.gui.components.ComponentContainer` as required in CUBA 7
+
+
 ### Dependencies
 - CUBA 7.0.x
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - Unreleased
+
+### Added
+- This release supports the usage within a CUBA 7 application. However - it does not support the new CUBA 7 Screen APIs.
+  This release is more for fast upgrading your existing application if you rely on this app component. CUBA 7 Screens API
+  will be supported in later releases.
+
+### Dependencies
+- CUBA 7.0.x
+
 ## [0.7.0] - 24.10.2018
 
 ### Dependencies
-- CUBA 6.9.x
+- CUBA 6.10.x
 
 ## [0.6.0] - 05.06.2018
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ CUBA component that allows to write generic features for a Controller and use th
 
 | Platform Version | Add-on Version |
 | ---------------- | -------------- |
+| 7.0.x            | 0.8.x          |
 | 6.10.x           | 0.7.x          |
 | 6.9.x            | 0.6.x          |
 | 6.8.x            | 0.5.x          |

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-    ext.cubaVersion = '6.10.2'
+    ext.cubaVersion = '7.0.0'
     repositories {
         maven {
             url 'https://repo.cuba-platform.com/content/groups/work'
@@ -19,22 +19,23 @@ buildscript {
     }
 }
 
-def globalModule = project(':declarativecontrollers-global')
-def coreModule = project(':declarativecontrollers-core')
-def guiModule = project(':declarativecontrollers-gui')
-def webModule = project(':declarativecontrollers-web')
+def modulePrefix = 'declarativecontrollers'
+
+def globalModule = project(":${modulePrefix}-global" )
+def coreModule = project(":${modulePrefix}-core" )
+def guiModule = project(":${modulePrefix}-gui" )
+def webModule = project(":${modulePrefix}-web" )
 
 def servletApi = 'javax.servlet:javax.servlet-api:3.1.0'
 
 
-apply(plugin: 'idea')
 apply(plugin: 'cuba')
 
 cuba {
     artifact {
         group = 'de.balvi.cuba.declarativecontrollers'
-        version = "0.7.0"
-        isSnapshot = false
+        version = "0.8.0"
+        isSnapshot = true
     }
     tomcat {
         dir = "$project.rootDir/deploy/tomcat"
@@ -83,7 +84,6 @@ test.finalizedBy(project.tasks.coberturaCheck)
 configure([globalModule, coreModule, guiModule, webModule]) {
     apply(plugin: 'java')
     apply(plugin: 'maven')
-    apply(plugin: 'idea')
     apply(plugin: 'cuba')
 
     dependencies {
@@ -166,7 +166,7 @@ configure(coreModule) {
 
     dependencies {
         compile(globalModule)
-        provided(servletApi)
+        compileOnly(servletApi)
         jdbc(hsql)
         testRuntime(hsql)
 
@@ -174,7 +174,7 @@ configure(coreModule) {
 
     task cleanConf(description: 'Cleans up conf directory') {
         doLast {
-            def dir = new File(cuba.tomcat.dir, '/conf/declarativecontrollers-core')
+            def dir = new File(cuba.tomcat.dir, "/conf/${modulePrefix}-core" )
             if (dir.isDirectory()) {
                 ant.delete(includeemptydirs: true) {
                     fileset(dir: dir, includes: '**/*', excludes: 'local.app.properties')
@@ -184,8 +184,8 @@ configure(coreModule) {
     }
 
     task deploy(dependsOn: [assemble, cleanConf], type: CubaDeployment) {
-        appName = 'declarativecontrollers-core'
-        appJars('declarativecontrollers-global', 'declarativecontrollers-core')
+        appName = "${modulePrefix}-core"
+        appJars(modulePrefix + '-global', modulePrefix + '-core')
     }
 
     task createDb(dependsOn: assembleDbScripts, description: 'Creates local database', type: CubaDbCreation) {
@@ -213,7 +213,7 @@ configure(guiModule) {
     task deployConf(type: Copy) {
         from file('src')
         include "de/balvi/cuba/declarativecontrollers/**"
-        into "$cuba.tomcat.dir/conf/declarativecontrollers"
+        into "$cuba.tomcat.dir/conf/${modulePrefix}"
     }
 }
 
@@ -223,7 +223,7 @@ configure(webModule) {
     }
 
     dependencies {
-        provided(servletApi)
+        compileOnly(servletApi)
         compile(guiModule)
     }
     
@@ -240,18 +240,18 @@ configure(webModule) {
     task deployConf(type: Copy) {
         from file('src')
         include "de/balvi/cuba/declarativecontrollers/**"
-        into "$cuba.tomcat.dir/conf/declarativecontrollers"
+        into "$cuba.tomcat.dir/conf/${modulePrefix}"
     }
 
     task clearMessagesCache(type: CubaClearMessagesCache) {
-        appName = 'declarativecontrollers'
+        appName = "${modulePrefix}"
     }
     
     deployConf.dependsOn clearMessagesCache
 
     task cleanConf(description: 'Cleans up conf directory') {
         doLast {
-            def dir = new File(cuba.tomcat.dir, '/conf/declarativecontrollers')
+            def dir = new File(cuba.tomcat.dir, "/conf/${modulePrefix}" )
             if (dir.isDirectory()) {
                 ant.delete(includeemptydirs: true) {
                     fileset(dir: dir, includes: '**/*', excludes: 'local.app.properties')
@@ -261,18 +261,18 @@ configure(webModule) {
     }
 
     task deploy(dependsOn: [assemble, cleanConf], type: CubaDeployment) {
-        appName = 'declarativecontrollers'
-        appJars('declarativecontrollers-global', 'declarativecontrollers-gui', 'declarativecontrollers-web')
+        appName = "${modulePrefix}"
+        appJars(modulePrefix + '-global', modulePrefix + '-gui', modulePrefix + '-web')
     }
 }
 
-task undeploy(type: Delete, dependsOn: ':declarativecontrollers-web:cleanConf') {
+task undeploy(type: Delete, dependsOn: ":${modulePrefix}-web:cleanConf" ) {
     delete("$cuba.tomcat.dir/shared")
-    delete("$cuba.tomcat.dir/webapps/declarativecontrollers-core")
-    delete("$cuba.tomcat.dir/webapps/declarativecontrollers")
+    delete("$cuba.tomcat.dir/webapps/${modulePrefix}-core" )
+    delete("$cuba.tomcat.dir/webapps/${modulePrefix}" )
 }
 
-task restart(dependsOn: ['stop', ':declarativecontrollers-core:deploy', ':declarativecontrollers-web:deploy'], description: 'Redeploys applications and restarts local Tomcat') {
+task restart(dependsOn: ['stop', ":${modulePrefix}-core:deploy" , ":${modulePrefix}-web:deploy" ], description: 'Redeploys applications and restarts local Tomcat') {
     doLast {
         ant.waitfor(maxwait: 6, maxwaitunit: 'second', checkevery: 2, checkeveryunit: 'second') {
             not {
@@ -283,9 +283,6 @@ task restart(dependsOn: ['stop', ':declarativecontrollers-core:deploy', ':declar
     }
 }
 
-task wrapper(type: Wrapper) {
-    gradleVersion = '4.3.1'
-}
 
 apply from: 'extra.gradle'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-bin.zip

--- a/modules/web/src/de/balvi/cuba/declarativecontrollers/web-spring.xml
+++ b/modules/web/src/de/balvi/cuba/declarativecontrollers/web-spring.xml
@@ -3,9 +3,11 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.3.xsd">
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.3.xsd"
+       xmlns:gui="http://schemas.haulmont.com/cuba/spring/cuba-gui.xsd">
 
     <!-- Annotation-based beans -->
     <context:component-scan base-package="de.balvi.cuba.declarativecontrollers"/>
+    <gui:screens base-packages="de.balvi.cuba.declarativecontrollers.web"/>
 
 </beans>

--- a/modules/web/src/de/balvi/cuba/declarativecontrollers/web/helper/ButtonsPanelHelper.java
+++ b/modules/web/src/de/balvi/cuba/declarativecontrollers/web/helper/ButtonsPanelHelper.java
@@ -2,7 +2,7 @@ package de.balvi.cuba.declarativecontrollers.web.helper;
 
 import com.haulmont.cuba.gui.components.Button;
 import com.haulmont.cuba.gui.components.ButtonsPanel;
-import com.haulmont.cuba.gui.components.Component;
+import com.haulmont.cuba.gui.components.ComponentContainer;
 
 import java.util.List;
 
@@ -19,7 +19,7 @@ public interface ButtonsPanelHelper {
      * @param buttonsPanelId the buttonsPanelId to search for
      * @return the Button, which either got created or has been found
      */
-    Button getOrCreateButton(Component.Container container, String buttonId, String buttonsPanelId);
+    Button getOrCreateButton(ComponentContainer container, String buttonId, String buttonsPanelId);
 
 
     /**

--- a/modules/web/src/de/balvi/cuba/declarativecontrollers/web/helper/ButtonsPanelHelperBean.groovy
+++ b/modules/web/src/de/balvi/cuba/declarativecontrollers/web/helper/ButtonsPanelHelperBean.groovy
@@ -1,8 +1,9 @@
 package de.balvi.cuba.declarativecontrollers.web.helper
 
+import com.haulmont.cuba.gui.UiComponents
 import com.haulmont.cuba.gui.components.Button
 import com.haulmont.cuba.gui.components.ButtonsPanel
-import com.haulmont.cuba.gui.xml.layout.ComponentsFactory
+import com.haulmont.cuba.gui.components.ComponentContainer
 import groovy.transform.CompileStatic
 import org.springframework.stereotype.Component
 
@@ -13,10 +14,10 @@ import javax.inject.Inject
 class ButtonsPanelHelperBean implements ButtonsPanelHelper{
 
     @Inject
-    ComponentsFactory componentsFactory
+    UiComponents uiComponents
 
     @Override
-    Button getOrCreateButton(com.haulmont.cuba.gui.components.Component.Container container, String buttonId, String buttonsPanelId) {
+    Button getOrCreateButton(ComponentContainer container, String buttonId, String buttonsPanelId) {
         Button button = container.getComponent(buttonId) as Button
         if (buttonsPanelId && !button) {
             ButtonsPanel buttonsPanel = container.getComponent(buttonsPanelId) as ButtonsPanel
@@ -31,7 +32,7 @@ class ButtonsPanelHelperBean implements ButtonsPanelHelper{
             return null
         }
 
-        Button button = componentsFactory.createComponent(Button)
+        Button button = uiComponents.create(Button)
         button.id = id
 
         Integer maxIndex = determineMaxButtonIndex(buttonsPanel, vorherigeButtonIds)

--- a/modules/web/web/WEB-INF/web.xml
+++ b/modules/web/web/WEB-INF/web.xml
@@ -3,11 +3,6 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
          version="3.0">
-    <context-param>
-        <description>Web resources version for correct caching in browser</description>
-        <param-name>webResourcesTs</param-name>
-        <param-value>${webResourcesTs}</param-value>
-    </context-param>
     <!-- Application properties config files -->
     <context-param>
         <param-name>appPropertiesConfig</param-name>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 rootProject.name = 'cuba-component-declarative-controllers'
-include(':declarativecontrollers-global', ':declarativecontrollers-core', ':declarativecontrollers-gui', ':declarativecontrollers-web')
-project(':declarativecontrollers-global').projectDir = new File(settingsDir, 'modules/global')
-project(':declarativecontrollers-core').projectDir = new File(settingsDir, 'modules/core')
-project(':declarativecontrollers-gui').projectDir = new File(settingsDir, 'modules/gui')
-project(':declarativecontrollers-web').projectDir = new File(settingsDir, 'modules/web')
+def modulePrefix = 'declarativecontrollers'
+include(":${modulePrefix}-global" , ":${modulePrefix}-core" , ":${modulePrefix}-gui" , ":${modulePrefix}-web" )
+project(":${modulePrefix}-global" ).projectDir = new File(settingsDir, 'modules/global')
+project(":${modulePrefix}-core" ).projectDir = new File(settingsDir, 'modules/core')
+project(":${modulePrefix}-gui" ).projectDir = new File(settingsDir, 'modules/gui')
+project(":${modulePrefix}-web" ).projectDir = new File(settingsDir, 'modules/web')

--- a/studio-intellij.xml
+++ b/studio-intellij.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CubaPluginProjectSettings">
+    <option name="isOneToOneIndex" value="false" />
+    <option name="isNewFkConstraintNaming" value="false" />
+    <option name="isJoinedInheritanceDeleteCascade" value="false" />
+  </component>
+</project>


### PR DESCRIPTION
Hi @bresche @jhbaumgarten @alferink,

this PR should enable CUBA 7 support for declarative-controllers. With support I mean that it is able to be used within a CUBA 7 application with the now old `AbstractEditor` and `AbstractLookup` controller classes. 

However, the new Screens API, that is introduced  in CUBA 7 with `StandardLookup`, `StandardEditor`  but more importantly the shift away from inheritance to delegation is **not** supported. (see: https://github.com/cuba-labs/screen-api-demos) 

More interestingly - it might be that the recently introduced possibility to use Mixin interfaces in the controller classes (also CUBA 7) will probably shift a lot of use cases from this plugin to the framework itself (which is good - because it means less dependencies in the apps using CUBA). Also the event based approach from CUBA 7 will help out here. For an example see: https://github.com/cuba-labs/screen-mixins-demo

I'm not sure if you have seen the new CUBA 7 screen APIs possibilities. I think mid-term it make sense to keep this plugin as is. But perhaps it might be an interesting discussion how this plugin should evolve now that we have much more options on the table provided by CUBA directly.

I created this PR for an easy & fast upgrade path for applications from CUBA 6.10 to 7.0. This means - the lease amount of changes, only support for the old way.
This gives the users (like a lot of my plugins) the opportunity to upgrade to 7.0 without the need to update everything to the new Screens API in the plugin hierarchy.

I've successfully run the [cuba-example-declarative-comments](https://github.com/balvi/cuba-example-declarative-comments) example with this version:

<img width="1392" alt="bildschirmfoto 2019-01-26 um 21 16 58" src="https://user-images.githubusercontent.com/817400/51792543-d43a5a00-21b2-11e9-9444-0af78f3a055f.png">
<img width="1392" alt="bildschirmfoto 2019-01-26 um 21 17 07" src="https://user-images.githubusercontent.com/817400/51792544-d4d2f080-21b2-11e9-8f16-8b6bf20b93c5.png">


