### PR TITLE
CUBA 7.2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.10.0] - 05.03.2020
+## [0.10.0] - 06.03.2020
 
 ### Dependencies
 - CUBA 7.2.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 05.03.2020
+
+### Dependencies
+- CUBA 7.2.x
+
 ## [0.9.0] - 18.09.2019
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ CUBA component that allows to write generic features for a Controller and use th
 
 | Platform Version | Add-on Version |
 | ---------------- | -------------- |
+| 7.2.x            | 0.10.x         |
 | 7.1.x            | 0.9.x          |
 | 7.0.x            | 0.8.x          |
 | 6.10.x           | 0.7.x          |

--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,8 @@ apply(plugin: 'cuba')
 cuba {
     artifact {
         group = 'de.balvi.cuba.declarativecontrollers'
-        version = "0.9.0"
-        isSnapshot = false
+        version = "0.10.0"
+        isSnapshot = true
     }
     tomcat {
         dir = "$project.rootDir/deploy/tomcat"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-    ext.cubaVersion = '7.1.0'
+    ext.cubaVersion = '7.2.0'
     repositories {
         maven {
             url 'https://repo.cuba-platform.com/content/groups/work'
@@ -137,10 +137,21 @@ configure([globalModule, coreModule, guiModule, webModule]) {
     test.finalizedBy(project.tasks.coberturaCheck)
 
     sourceSets {
-        main { groovy { srcDirs = ["src"] } }
-        test { groovy { srcDirs = ["test"] } }
+        main {
+            groovy { srcDirs = ["src"] }
+            // new config
+            java.outputDir = new File(project.buildDir, "classes/main")
+            groovy.outputDir = new File(project.buildDir, "classes/main")
+        }
+        test {
+            groovy { srcDirs = ["test"] }
+            // new config
+            java.outputDir = new File(project.buildDir, "classes/test")
+            groovy.outputDir = new File(project.buildDir, "classes/test")
+        }
     }
-
+            sourceSets.main.output.classesDirs.setFrom(new File(project.buildDir, "classes/main"))
+            sourceSets.test.output.classesDirs.setFrom(new File(project.buildDir, "classes/test"))
 
 
 }
@@ -172,15 +183,8 @@ configure(coreModule) {
 
     }
 
-    task cleanConf(description: 'Cleans up conf directory') {
-        doLast {
-            def dir = new File(cuba.tomcat.dir, "/conf/${modulePrefix}-core" )
-            if (dir.isDirectory()) {
-                ant.delete(includeemptydirs: true) {
-                    fileset(dir: dir, includes: '**/*', excludes: 'local.app.properties')
-                }
-            }
-        }
+    task cleanConf(description: 'Cleans up conf directory', type: Delete) {
+        delete "$cuba.appHome/${modulePrefix}-core/conf"
     }
 
     task deploy(dependsOn: [assemble, cleanConf], type: CubaDeployment) {
@@ -213,7 +217,7 @@ configure(guiModule) {
     task deployConf(type: Copy) {
         from file('src')
         include "de/balvi/cuba/declarativecontrollers/**"
-        into "$cuba.tomcat.dir/conf/${modulePrefix}"
+        into "$cuba.appHome/${modulePrefix}/conf"
     }
 }
 
@@ -240,7 +244,7 @@ configure(webModule) {
     task deployConf(type: Copy) {
         from file('src')
         include "de/balvi/cuba/declarativecontrollers/**"
-        into "$cuba.tomcat.dir/conf/${modulePrefix}"
+        into "$cuba.appHome/${modulePrefix}/conf"
     }
 
     task clearMessagesCache(type: CubaClearMessagesCache) {
@@ -249,15 +253,8 @@ configure(webModule) {
     
     deployConf.dependsOn clearMessagesCache
 
-    task cleanConf(description: 'Cleans up conf directory') {
-        doLast {
-            def dir = new File(cuba.tomcat.dir, "/conf/${modulePrefix}" )
-            if (dir.isDirectory()) {
-                ant.delete(includeemptydirs: true) {
-                    fileset(dir: dir, includes: '**/*', excludes: 'local.app.properties')
-                }
-            }
-        }
+    task cleanConf(description: 'Cleans up conf directory', type: Delete) {
+        delete "$cuba.appHome/${modulePrefix}/conf"
     }
 
     task deploy(dependsOn: [assemble, cleanConf], type: CubaDeployment) {
@@ -279,9 +276,9 @@ task restart(dependsOn: ['stop', ":${modulePrefix}-core:deploy" , ":${modulePref
                 socket(server: 'localhost', port: '8787')
             }
         }
-        start.execute()
     }
 }
+restart.finalizedBy start
 
 
 apply from: 'extra.gradle'

--- a/fork-utils/add-upstream.sh
+++ b/fork-utils/add-upstream.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+git remote add upstream git@github.com:balvi/cuba-component-declarative-controllers.git
+

--- a/fork-utils/add-upstream.sh
+++ b/fork-utils/add-upstream.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
 
 git remote add upstream git@github.com:balvi/cuba-component-declarative-controllers.git
-

--- a/fork-utils/update-from-upstream.sh
+++ b/fork-utils/update-from-upstream.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+git fetch upstream
+git checkout master
+git merge upstream/master
+
+echo "Update done... git push as the next step."

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip

--- a/modules/core/src/de/balvi/cuba/declarativecontrollers/app.properties
+++ b/modules/core/src/de/balvi/cuba/declarativecontrollers/app.properties
@@ -27,3 +27,6 @@ cuba.availableLocales = English|en
 cuba.localeSelectVisible = false
 cuba.restApiUrl = http://localhost:8080/declarativecontrollers-portal/api
 cuba.webAppUrl = http://localhost:8080/declarativecontrollers
+cuba.security.rolesPolicyVersion=1
+cuba.security.defaultPermissionValuesConfigEnabled=true
+cuba.security.minimalRoleIsDefault=false

--- a/modules/web/src/de/balvi/cuba/declarativecontrollers/web-app.properties
+++ b/modules/web/src/de/balvi/cuba/declarativecontrollers/web-app.properties
@@ -48,3 +48,4 @@ cuba.webAppUrl = http://localhost:8080/declarativecontrollers
 cuba.web.loginScreenId=loginWindow
 cuba.web.mainScreenId=mainWindow
 cuba.gui.genericFilterApplyImmediately=false
+cuba.rest.securityScope=GENERIC_UI

--- a/studio-intellij.xml
+++ b/studio-intellij.xml
@@ -4,5 +4,6 @@
     <option name="isOneToOneIndex" value="false" />
     <option name="isNewFkConstraintNaming" value="false" />
     <option name="isJoinedInheritanceDeleteCascade" value="false" />
+    <option name="stateVersion" value="1" />
   </component>
 </project>


### PR DESCRIPTION
Hi,

this PR adds support for CUBA 7.2.0.

It does still not change anything regarding the new CUBA Screen API, it is only there to support the new platform version with the old screen types.

It seems to work - see screenshots:

<img width="1392" alt="products-comments" src="https://user-images.githubusercontent.com/817400/76059829-2043fa80-5f80-11ea-914e-014a15daf539.png">
<img width="1392" alt="customer-comments-icon" src="https://user-images.githubusercontent.com/817400/76059816-1c17dd00-5f80-11ea-9f4f-715f04614bc5.png">
<img width="1392" alt="products-browse" src="https://user-images.githubusercontent.com/817400/76059825-1f12cd80-5f80-11ea-839a-a825d68eed7d.png">

Updated example:
https://github.com/balvi/cuba-example-declarative-comments/pull/4