### PR TITLE
Added support for Cuba 7 UI API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ apply(plugin: 'cuba')
 cuba {
     artifact {
         group = 'de.balvi.cuba.declarativecontrollers'
-        version = "0.10.0"
+        version = '0.11.0'
         isSnapshot = false
     }
     tomcat {

--- a/modules/web/src/de/balvi/cuba/declarativecontrollers/web/annotationexecutor/AbstractAnnotationDispatcherBean.java
+++ b/modules/web/src/de/balvi/cuba/declarativecontrollers/web/annotationexecutor/AbstractAnnotationDispatcherBean.java
@@ -1,6 +1,7 @@
 package de.balvi.cuba.declarativecontrollers.web.annotationexecutor;
 
 import com.haulmont.cuba.gui.components.Frame;
+import com.haulmont.cuba.gui.screen.Screen;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
@@ -9,23 +10,22 @@ import java.util.Collection;
 
 abstract public class AbstractAnnotationDispatcherBean<T extends AnnotationExecutor, K extends AnnotationExecutor> {
 
-    protected Field[] getDeclaredFields(Frame frame) {
-        return frame.getClass().getDeclaredFields();
+    protected Field[] getDeclaredFields(Screen screen) {
+        return screen.getClass().getDeclaredFields();
     }
 
-    protected com.haulmont.cuba.gui.components.Component getFieldValue(Frame frame, Field field) {
+    protected com.haulmont.cuba.gui.components.Component getFieldValue(Screen screen, Field field) {
         try {
             field.setAccessible(true);
-            return (com.haulmont.cuba.gui.components.Component) field.get(frame);
+            return (com.haulmont.cuba.gui.components.Component) field.get(screen);
         } catch (IllegalAccessException e) {
             e.printStackTrace();
             return null;
         }
     }
 
-
-    protected Annotation[] getClassAnnotations(Frame frame) {
-        return frame.getClass().getAnnotations();
+    protected Annotation[] getClassAnnotations(Screen screen) {
+        return screen.getClass().getAnnotations();
     }
 
     protected Collection<? extends AnnotationExecutor> getSupportedAnnotationExecutors(Collection<? extends AnnotationExecutor> potentialAnnotationExecutors, Annotation annotation) {

--- a/modules/web/src/de/balvi/cuba/declarativecontrollers/web/annotationexecutor/screen/ScreenAnnotationExecutor.java
+++ b/modules/web/src/de/balvi/cuba/declarativecontrollers/web/annotationexecutor/screen/ScreenAnnotationExecutor.java
@@ -1,0 +1,17 @@
+package de.balvi.cuba.declarativecontrollers.web.annotationexecutor.screen;
+
+import com.haulmont.cuba.gui.components.Window;
+import com.haulmont.cuba.gui.screen.Screen;
+import com.haulmont.cuba.gui.screen.ScreenOptions;
+import de.balvi.cuba.declarativecontrollers.web.annotationexecutor.AnnotationExecutor;
+
+import java.lang.annotation.Annotation;
+import java.util.Map;
+
+public interface ScreenAnnotationExecutor<A extends Annotation> extends AnnotationExecutor {
+
+    void init(A annotation, Screen screen, ScreenOptions options);
+
+    void beforeShow(A annotation, Screen screen, ScreenOptions options);
+
+}

--- a/modules/web/src/de/balvi/cuba/declarativecontrollers/web/annotationexecutor/screen/ScreenFieldAnnotationExecutor.java
+++ b/modules/web/src/de/balvi/cuba/declarativecontrollers/web/annotationexecutor/screen/ScreenFieldAnnotationExecutor.java
@@ -1,0 +1,16 @@
+package de.balvi.cuba.declarativecontrollers.web.annotationexecutor.screen;
+
+import com.haulmont.cuba.gui.components.Component;
+import com.haulmont.cuba.gui.screen.Screen;
+import com.haulmont.cuba.gui.screen.ScreenOptions;
+import de.balvi.cuba.declarativecontrollers.web.annotationexecutor.AnnotationExecutor;
+
+import java.lang.annotation.Annotation;
+
+public interface ScreenFieldAnnotationExecutor<A extends Annotation, T extends Component> extends AnnotationExecutor {
+
+    void init(A annotation, Screen screen, T target, ScreenOptions options);
+
+    void beforeshow(A annotation, Screen screen, T target, ScreenOptions options);
+
+}

--- a/modules/web/src/de/balvi/cuba/declarativecontrollers/web/screen/AnnotatableScreen.java
+++ b/modules/web/src/de/balvi/cuba/declarativecontrollers/web/screen/AnnotatableScreen.java
@@ -12,14 +12,17 @@ public class AnnotatableScreen extends Screen {
     protected ScreenAnnotationDispatcher screenAnnotationDispatcher;
     private ScreenOptions screenOptions;
 
-    @Subscribe
-    public void onInit(InitEvent event) {
+    public AnnotatableScreen(){
+        addInitListener(this::onInitEvent);
+        addBeforeShowListener(this::onBeforeShowEvent);
+    }
+
+    public void onInitEvent(InitEvent event) {
         this.screenOptions = event.getOptions();
         screenAnnotationDispatcher.executeInit(this, screenOptions);
     }
 
-    @Subscribe
-    public void onBeforeShow(BeforeShowEvent event) {
+    public void onBeforeShowEvent(BeforeShowEvent event) {
         screenAnnotationDispatcher.executeBeforeShow(this, screenOptions);
     }
 

--- a/modules/web/src/de/balvi/cuba/declarativecontrollers/web/screen/AnnotatableScreen.java
+++ b/modules/web/src/de/balvi/cuba/declarativecontrollers/web/screen/AnnotatableScreen.java
@@ -1,0 +1,26 @@
+package de.balvi.cuba.declarativecontrollers.web.screen;
+
+import com.haulmont.cuba.gui.screen.Screen;
+import com.haulmont.cuba.gui.screen.ScreenOptions;
+import com.haulmont.cuba.gui.screen.Subscribe;
+
+import javax.inject.Inject;
+
+public class AnnotatableScreen extends Screen {
+
+    @Inject
+    protected ScreenAnnotationDispatcher screenAnnotationDispatcher;
+    private ScreenOptions screenOptions;
+
+    @Subscribe
+    public void onInit(InitEvent event) {
+        this.screenOptions = event.getOptions();
+        screenAnnotationDispatcher.executeInit(this, screenOptions);
+    }
+
+    @Subscribe
+    public void onBeforeShow(BeforeShowEvent event) {
+        screenAnnotationDispatcher.executeBeforeShow(this, screenOptions);
+    }
+
+}

--- a/modules/web/src/de/balvi/cuba/declarativecontrollers/web/screen/ScreenAnnotationDispatcher.java
+++ b/modules/web/src/de/balvi/cuba/declarativecontrollers/web/screen/ScreenAnnotationDispatcher.java
@@ -1,0 +1,13 @@
+package de.balvi.cuba.declarativecontrollers.web.screen;
+
+import com.haulmont.cuba.gui.screen.Screen;
+import com.haulmont.cuba.gui.screen.ScreenOptions;
+import de.balvi.cuba.declarativecontrollers.web.standardbrowse.AnnotatableStandardLookup;
+
+public interface ScreenAnnotationDispatcher {
+
+    String NAME = "dbcdc_ScreenAnnotationExecutorService";
+
+    void executeInit(Screen screen, ScreenOptions screenOptions);
+    void executeBeforeShow(Screen screen, ScreenOptions screenOptions);
+}

--- a/modules/web/src/de/balvi/cuba/declarativecontrollers/web/screen/ScreenAnnotationDispatcherBean.java
+++ b/modules/web/src/de/balvi/cuba/declarativecontrollers/web/screen/ScreenAnnotationDispatcherBean.java
@@ -1,0 +1,117 @@
+package de.balvi.cuba.declarativecontrollers.web.screen;
+
+import com.haulmont.cuba.core.global.AppBeans;
+import com.haulmont.cuba.gui.screen.Screen;
+import com.haulmont.cuba.gui.screen.ScreenOptions;
+import de.balvi.cuba.declarativecontrollers.web.annotationexecutor.AbstractAnnotationDispatcherBean;
+import de.balvi.cuba.declarativecontrollers.web.annotationexecutor.screen.ScreenAnnotationExecutor;
+import de.balvi.cuba.declarativecontrollers.web.annotationexecutor.screen.ScreenFieldAnnotationExecutor;
+import groovy.transform.CompileStatic;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.Collection;
+
+@CompileStatic
+@Component(ScreenAnnotationDispatcher.NAME)
+public class ScreenAnnotationDispatcherBean extends AbstractAnnotationDispatcherBean<ScreenAnnotationExecutor, ScreenFieldAnnotationExecutor> implements ScreenAnnotationDispatcher {
+
+    @Override
+    public void executeInit(Screen screen, ScreenOptions screenOptions) {
+        executeInitUniversal(screen, screenOptions);
+    }
+
+    private void executeInitUniversal(Screen screen, ScreenOptions screenOptions) {
+        executeInitForClassAnnotations(screen, screenOptions);
+        executeInitForFieldAnnotations(screen, screenOptions);
+    }
+
+    private void executeInitForFieldAnnotations(Screen screen, ScreenOptions screenOptions) {
+        for (Field field : getDeclaredFields(screen)) {
+            Annotation[] fieldAnnotations = field.getAnnotations();
+
+            for (Annotation annotation : fieldAnnotations) {
+
+                Collection<ScreenFieldAnnotationExecutor> supportedAnnotationExecutors = getSupportedScreenFieldAnnotationExecutors(annotation);
+
+                if (supportedAnnotationExecutors != null && supportedAnnotationExecutors.size() > 0) {
+                    com.haulmont.cuba.gui.components.Component fieldValue = getFieldValue(screen, field);
+                    for (ScreenFieldAnnotationExecutor annotationExecutor : supportedAnnotationExecutors) {
+                        annotationExecutor.init(annotation, screen, fieldValue, screenOptions);
+                    }
+                }
+
+            }
+        }
+    }
+
+    private void executeInitForClassAnnotations(Screen screen, ScreenOptions screenOptions) {
+        for (Annotation annotation : getClassAnnotations(screen)) {
+            Collection<ScreenAnnotationExecutor> supportedAnnotationExecutors = getSupportedScreenAnnotationExecutors(annotation);
+
+            for (ScreenAnnotationExecutor annotationExecutor : supportedAnnotationExecutors) {
+                annotationExecutor.init(annotation, screen, screenOptions);
+            }
+        }
+    }
+
+    @Override
+    public void executeBeforeShow(Screen screen, ScreenOptions screenOptions) {
+        executeBeforeShowUniversal(screen, screenOptions);
+    }
+
+    private void executeBeforeShowUniversal(Screen screen, ScreenOptions screenOptions){
+        executeBeforeShowForClassAnnotations(screen, screenOptions);
+        executeBeforeShowForFieldAnnotations(screen, screenOptions);
+    }
+
+    private void executeBeforeShowForFieldAnnotations(Screen screen, ScreenOptions screenOptions) {
+        for (Field field : getDeclaredFields(screen)) {
+
+            Annotation[] fieldAnnotations = field.getAnnotations();
+            for (Annotation annotation : fieldAnnotations) {
+
+                Collection<ScreenFieldAnnotationExecutor> supportedAnnotationExecutors = getSupportedScreenFieldAnnotationExecutors(annotation);
+
+                if (supportedAnnotationExecutors != null && supportedAnnotationExecutors.size() > 0) {
+                    com.haulmont.cuba.gui.components.Component fieldValue = getFieldValue(screen, field);
+                    for (ScreenFieldAnnotationExecutor annotationExecutor : supportedAnnotationExecutors) {
+                        annotationExecutor.beforeshow(annotation, screen, fieldValue, screenOptions);
+                    }
+                }
+            }
+        }
+    }
+
+    private void executeBeforeShowForClassAnnotations(Screen screen, ScreenOptions screenOptions) {
+        for (Annotation annotation : getClassAnnotations(screen)) {
+
+            Collection<ScreenAnnotationExecutor> supportedAnnotations = getSupportedScreenAnnotationExecutors(annotation);
+
+            for (ScreenAnnotationExecutor annotationExecutor : supportedAnnotations) {
+                annotationExecutor.beforeShow(annotation, screen, screenOptions);
+            }
+        }
+    }
+
+
+    protected Collection<ScreenAnnotationExecutor> getSupportedScreenAnnotationExecutors(Annotation annotation) {
+        Collection<ScreenAnnotationExecutor> annotationExecutors = getScreenAnnotationExecutors();
+        return (Collection<ScreenAnnotationExecutor>) getSupportedAnnotationExecutors(annotationExecutors, annotation);
+    }
+
+    protected Collection<ScreenFieldAnnotationExecutor> getSupportedScreenFieldAnnotationExecutors(Annotation annotation) {
+        Collection<ScreenFieldAnnotationExecutor> annotationExecutors = getScreenFieldAnnotationExecutors();
+        return (Collection<ScreenFieldAnnotationExecutor>) getSupportedAnnotationExecutors(annotationExecutors, annotation);
+    }
+
+    protected Collection<ScreenAnnotationExecutor> getScreenAnnotationExecutors() {
+        return AppBeans.getAll(ScreenAnnotationExecutor.class).values();
+    }
+
+
+    protected Collection<ScreenFieldAnnotationExecutor> getScreenFieldAnnotationExecutors() {
+        return AppBeans.getAll(ScreenFieldAnnotationExecutor.class).values();
+    }
+}

--- a/modules/web/src/de/balvi/cuba/declarativecontrollers/web/standardbrowse/AnnotatableStandardLookup.java
+++ b/modules/web/src/de/balvi/cuba/declarativecontrollers/web/standardbrowse/AnnotatableStandardLookup.java
@@ -14,14 +14,17 @@ public class AnnotatableStandardLookup<T extends Entity> extends StandardLookup<
     protected ScreenAnnotationDispatcher screenAnnotationDispatcher;
     private ScreenOptions screenOptions;
 
-    @Subscribe
-    public void onInit(InitEvent event) {
+    public AnnotatableStandardLookup(){
+        addInitListener(this::onInitEvent);
+        addBeforeShowListener(this::onBeforeShowEvent);
+    }
+
+    public void onInitEvent(InitEvent event) {
         this.screenOptions = event.getOptions();
         screenAnnotationDispatcher.executeInit(this, screenOptions);
     }
 
-    @Subscribe
-    public void onBeforeShow(BeforeShowEvent event) {
+    public void onBeforeShowEvent(BeforeShowEvent event) {
         screenAnnotationDispatcher.executeBeforeShow(this, screenOptions);
     }
 }

--- a/modules/web/src/de/balvi/cuba/declarativecontrollers/web/standardbrowse/AnnotatableStandardLookup.java
+++ b/modules/web/src/de/balvi/cuba/declarativecontrollers/web/standardbrowse/AnnotatableStandardLookup.java
@@ -1,0 +1,27 @@
+package de.balvi.cuba.declarativecontrollers.web.standardbrowse;
+
+import com.haulmont.cuba.core.entity.Entity;
+import com.haulmont.cuba.gui.screen.ScreenOptions;
+import com.haulmont.cuba.gui.screen.StandardLookup;
+import com.haulmont.cuba.gui.screen.Subscribe;
+import de.balvi.cuba.declarativecontrollers.web.screen.ScreenAnnotationDispatcher;
+
+import javax.inject.Inject;
+
+public class AnnotatableStandardLookup<T extends Entity> extends StandardLookup<T> {
+
+    @Inject
+    protected ScreenAnnotationDispatcher screenAnnotationDispatcher;
+    private ScreenOptions screenOptions;
+
+    @Subscribe
+    public void onInit(InitEvent event) {
+        this.screenOptions = event.getOptions();
+        screenAnnotationDispatcher.executeInit(this, screenOptions);
+    }
+
+    @Subscribe
+    public void onBeforeShow(BeforeShowEvent event) {
+        screenAnnotationDispatcher.executeBeforeShow(this, screenOptions);
+    }
+}

--- a/modules/web/src/de/balvi/cuba/declarativecontrollers/web/standardeditor/AnnotatableStandardEditor.java
+++ b/modules/web/src/de/balvi/cuba/declarativecontrollers/web/standardeditor/AnnotatableStandardEditor.java
@@ -1,0 +1,27 @@
+package de.balvi.cuba.declarativecontrollers.web.standardeditor;
+
+import com.haulmont.cuba.core.entity.Entity;
+import com.haulmont.cuba.gui.screen.ScreenOptions;
+import com.haulmont.cuba.gui.screen.StandardEditor;
+import com.haulmont.cuba.gui.screen.Subscribe;
+import de.balvi.cuba.declarativecontrollers.web.screen.ScreenAnnotationDispatcher;
+
+import javax.inject.Inject;
+
+public class AnnotatableStandardEditor<T extends Entity> extends StandardEditor<T> {
+
+    @Inject
+    protected ScreenAnnotationDispatcher screenAnnotationDispatcher;
+    private ScreenOptions screenOptions;
+
+    @Subscribe
+    public void onInit(InitEvent event) {
+        this.screenOptions = event.getOptions();
+        screenAnnotationDispatcher.executeInit(this, screenOptions);
+    }
+
+    @Subscribe
+    public void onBeforeShow(BeforeShowEvent event) {
+        screenAnnotationDispatcher.executeBeforeShow(this, screenOptions);
+    }
+}

--- a/modules/web/src/de/balvi/cuba/declarativecontrollers/web/standardeditor/AnnotatableStandardEditor.java
+++ b/modules/web/src/de/balvi/cuba/declarativecontrollers/web/standardeditor/AnnotatableStandardEditor.java
@@ -14,14 +14,17 @@ public class AnnotatableStandardEditor<T extends Entity> extends StandardEditor<
     protected ScreenAnnotationDispatcher screenAnnotationDispatcher;
     private ScreenOptions screenOptions;
 
-    @Subscribe
-    public void onInit(InitEvent event) {
+    public AnnotatableStandardEditor(){
+        addInitListener(this::onInitEvent);
+        addBeforeShowListener(this::onBeforeShowEvent);
+    }
+
+    public void onInitEvent(InitEvent event) {
         this.screenOptions = event.getOptions();
         screenAnnotationDispatcher.executeInit(this, screenOptions);
     }
 
-    @Subscribe
-    public void onBeforeShow(BeforeShowEvent event) {
+    public void onBeforeShowEvent(BeforeShowEvent event) {
         screenAnnotationDispatcher.executeBeforeShow(this, screenOptions);
     }
 }

--- a/modules/web/test/de/balvi/cuba/declarativecontrollers/web/screen/ScreenAnnotationDispatcherBeanSpec.groovy
+++ b/modules/web/test/de/balvi/cuba/declarativecontrollers/web/screen/ScreenAnnotationDispatcherBeanSpec.groovy
@@ -1,0 +1,175 @@
+package de.balvi.cuba.declarativecontrollers.web.screen
+
+import com.haulmont.cuba.gui.screen.ScreenOptions
+import de.balvi.cuba.declarativecontrollers.web.annotationexecutor.screen.ScreenAnnotationExecutor
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
+import spock.lang.Specification
+
+class ScreenAnnotationDispatcherBeanSpec extends Specification {
+    ScreenAnnotationDispatcher screenAnnotationExecutorService
+    ScreenAnnotationExecutor executor
+    ScreenAnnotationExecutor executor2
+
+    def setup() {
+        executor = Mock()
+        executor2 = Mock()
+
+        screenAnnotationExecutorService = new ScreenAnnotationDispatcherMock([executor, executor2])
+    }
+
+    void 'executeInit does nothing if the browser has no annotations'() {
+
+        given:
+        AnnotatableScreen screen = Mock()
+        ScreenOptions screenOptions = Mock()
+
+        when:
+        screenAnnotationExecutorService.executeInit(screen, screenOptions)
+
+        then:
+        0 * executor.init(_, _, _)
+    }
+
+    void 'executeInit executes init if an Annotation is supported'() {
+
+        given:
+        AnnotatableScreen screen = new MyBrowseWithAnnotation()
+        ScreenOptions screenOptions = Mock()
+
+        and:
+        executor.supports(_ as ToString) >> true
+
+        when:
+        screenAnnotationExecutorService.executeInit(screen, screenOptions)
+
+        then:
+        1 * executor.init(_, _, _)
+        0 * executor2.init(_, _, _)
+    }
+
+    void 'executeInit executes init on every AnnotationExecutor that supports the Annotation'() {
+
+        given:
+        AnnotatableScreen screen = new MyBrowseWithAnnotation()
+        ScreenOptions screenOptions = Mock()
+
+        and:
+        executor.supports(_ as ToString) >> true
+        executor2.supports(_ as ToString) >> true
+
+        when:
+        screenAnnotationExecutorService.executeInit(screen, screenOptions)
+
+        then:
+        1 * executor.init(_, _, _)
+        1 * executor2.init(_, _, _)
+    }
+
+    void 'executeInit does nothing if there is no AnnotationExecutor for this Annotation'() {
+
+        given:
+        AnnotatableScreen browse = new MyBrowseWithAnnotation()
+        ScreenOptions screenOptions = Mock()
+
+        and:
+        executor.supports(_ as EqualsAndHashCode) >> false
+
+        when:
+        screenAnnotationExecutorService.executeInit(browse, screenOptions)
+
+        then:
+        0 * executor.init(_, _, _)
+    }
+
+
+
+
+
+
+
+
+
+
+    void 'executeBeforeShow does nothing if the browser has no annotations'() {
+
+        given:
+        AnnotatableScreen screen = Mock()
+        ScreenOptions screenOptions = Mock()
+
+        when:
+        screenAnnotationExecutorService.executeBeforeShow(screen, screenOptions)
+
+        then:
+        0 * executor.beforeShow(_, _, _)
+    }
+
+    void 'executeBeforeShow executes init if an Annotation is supported'() {
+
+        given:
+        AnnotatableScreen screen = new MyBrowseWithAnnotation()
+        ScreenOptions screenOptions = Mock()
+
+        and:
+        executor.supports(_ as ToString) >> true
+
+        when:
+        screenAnnotationExecutorService.executeBeforeShow(screen, screenOptions)
+
+        then:
+        1 * executor.beforeShow(_, _, _)
+        0 * executor2.beforeShow(_, _, _)
+    }
+
+    void 'executeBeforeShow executes init on every AnnotationExecutor that supports the Annotation'() {
+
+        given:
+        AnnotatableScreen screen = new MyBrowseWithAnnotation()
+        ScreenOptions screenOptions = Mock()
+
+        and:
+        executor.supports(_ as ToString) >> true
+        executor2.supports(_ as ToString) >> true
+
+        when:
+        screenAnnotationExecutorService.executeBeforeShow(screen, screenOptions)
+
+        then:
+        1 * executor.beforeShow(_, _, _)
+        1 * executor2.beforeShow(_, _, _)
+    }
+
+    void 'executeBeforeShow does nothing if there is no AnnotationExecutor for this Annotation'() {
+
+        given:
+        AnnotatableScreen screen = new MyBrowseWithAnnotation()
+        ScreenOptions screenOptions = Mock()
+
+        and:
+        executor.supports(_ as EqualsAndHashCode) >> false
+
+        when:
+        screenAnnotationExecutorService.executeBeforeShow(screen, screenOptions)
+
+        then:
+        0 * executor.beforeShow(_, _, _)
+    }
+}
+
+class ScreenAnnotationDispatcherMock extends ScreenAnnotationDispatcherBean {
+
+    Collection<ScreenAnnotationExecutor> annotationExecutorCollection
+
+    ScreenAnnotationDispatcherMock(Collection<ScreenAnnotationExecutor> annotationExecutorCollection) {
+        this.annotationExecutorCollection = annotationExecutorCollection
+    }
+
+    @Override
+    protected Collection<ScreenAnnotationExecutor> getScreenAnnotationExecutors() {
+        return annotationExecutorCollection
+    }
+}
+
+@ToString
+class MyBrowseWithAnnotation extends AnnotatableScreen {
+}


### PR DESCRIPTION
Hi!

I added support for new Cuba 7 UI API while still supporting old screen API (#13) .

As `StandardLookup` and `StandardEditor` both have the same events as ony other `Screen` I added backend only for generic `Screen` so it is not duplicated for each `Screen` type.

Tested with Cuba Platform 7.2.7 and updated HelpSystem addon (I'll make PR for that later as well).